### PR TITLE
Front end filter component now filters product categories

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -15,8 +15,13 @@ export default function Filter({ productCount, onSearch, locations }) {
 
   const [showFilters, setShowFilters] = useState(false)
   const [query, setQuery] = useState('')
-  const [categories, setCategories] = useState([{id: 1, name: 'Apples'}, {id: 2, name: 'Oranges'}, {id: 3, name: 'Lemons'}])
+  const [categories, setCategories] = useState([])
   const [direction, setDirection] = useState('asc')
+
+  useEffect(() => {
+    getCategories().then((data) => { setCategories(data) })
+  }, [])
+
   const clear = () => {
     for (let ref in refEls) {
       if (ref === 'direction') {
@@ -122,6 +127,7 @@ export default function Filter({ productCount, onSearch, locations }) {
                     options={locations}
                     title="Filter by Location"
                     addlClass="is-fullwidth"
+                    // Todo: ticket:#15
                   />
                 </div>
                 <hr className="dropdown-divider"></hr>

--- a/components/filter.js
+++ b/components/filter.js
@@ -127,7 +127,7 @@ export default function Filter({ productCount, onSearch, locations }) {
                     options={locations}
                     title="Filter by Location"
                     addlClass="is-fullwidth"
-                    // Todo: ticket:#15
+                  
                   />
                 </div>
                 <hr className="dropdown-divider"></hr>

--- a/data/products.js
+++ b/data/products.js
@@ -15,7 +15,7 @@ export function getProducts(query=undefined) {
 }
 
 export function getCategories() {
-  return fetchWithResponse('categories', {
+  return fetchWithResponse('productcategories', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }


### PR DESCRIPTION
Description of PR that completes issue here...
Front end filter component now filters product categories
originally there was a hard coded list of fruits in the category useState.

## Changes

- changed the category use state to be an empty array
- added a useEffect to get and set categories
- updated the filters GET function to get product categories to match the request in the back end. 

## Requests / Responses


## Testing

Description of how to test code...

- on the products page select the filter products option on the top right. 
- choose a category and then select filter
- this should pull up the related items in that category


## Related Issues

- Fixes #85
- Fixes #22