### PR TITLE
Bug/fix register

### DIFF
--- a/context/state.js
+++ b/context/state.js
@@ -17,7 +17,7 @@ export function AppWrapper({ children }) {
     const authRoutes = ['/login', '/register']
     if (token) {
       localStorage.setItem('token', token)
-      if (!authRoutes.includes(router.pathname)) {
+      if (authRoutes.includes(router.pathname)) {
         getUserProfile().then((profileData) => {
           if (profileData) {
             setProfile(profileData)

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -8,7 +8,7 @@ const checkError = (res) => {
 }
 
 const checkErrorJson = (res) => {
-  if (res.status !== 200) {
+  if (res.status !== 200 && res.status !== 201) {
     throw Error(res.status);
   } else {
     return res.json()

--- a/pages/register.js
+++ b/pages/register.js
@@ -14,6 +14,9 @@ export default function Register() {
   const lastName = useRef('')
   const username = useRef('')
   const password = useRef('')
+  const email = useRef('')
+  const phone_number = useRef('')
+  const address = useRef('')
   const router = useRouter()
 
   const submit = (e) => {
@@ -23,10 +26,14 @@ export default function Register() {
       username: username.current.value,
       password: password.current.value,
       first_name: firstName.current.value,
-      last_name: lastName.current.value
+      last_name: lastName.current.value,
+      email: email.current.value,
+      phone_number: phone_number.current.value,
+      address: address.current.value
     }
 
     register(user).then((res) => {
+      debugger
       if (res.token) {
         setToken(res.token)
         router.push('/')
@@ -59,10 +66,28 @@ export default function Register() {
             label="Username"
           />
           <Input
+            id="email"
+            refEl={email}
+            type="email"
+            label="Email"
+          />
+          <Input
             id="password"
             refEl={password}
             type="password"
             label="Password"
+          />
+          <Input
+            id="phone_number"
+            refEl={phone_number}
+            type="tel"
+            label="Phone Number"
+          />
+          <Input
+            id="address"
+            refEl={address}
+            type="text"
+            label="Address"
           />
 
           <div className="field is-grouped">

--- a/pages/register.js
+++ b/pages/register.js
@@ -32,7 +32,6 @@ export default function Register() {
       address: address.current.value
     }
 
-    debugger
     register(user).then((res) => {
       if (res.token) {
         setToken(res.token)

--- a/pages/register.js
+++ b/pages/register.js
@@ -32,8 +32,8 @@ export default function Register() {
       address: address.current.value
     }
 
+    debugger
     register(user).then((res) => {
-      debugger
       if (res.token) {
         setToken(res.token)
         router.push('/')


### PR DESCRIPTION
New users were unable to register a new account. This fixes that issue. Also the state was not correctly fetching user info once they login or register. So we fixed that logic.

## Changes

- pages/register.js
- data/fetcher.js
- context/state.js

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/register` Creates a new account

```json
{
	"username": "steven",
	"password": "Admin8*",
	"email": "steven@stevebrownlee.com",
	"address": "100 Infinity Way",
	"phone_number": "555-1212",
	"first_name": "Steve",
	"last_name": "Brownlee"
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "token": "bc8caebcdcf98f95e64c9061bc012ecfb3c67b7f",
    "id": 13
}
```

## Testing

- Register a new user on /register
- try logging in with the new created account


## Related Issues

- Fixes #77
- Fixes #79