### PR TITLE
Bug: User unable to add product to store

### DIFF
--- a/pages/products/new.js
+++ b/pages/products/new.js
@@ -13,8 +13,8 @@ export default function NewProduct() {
     const product = {
       name: name.value,
       description: description.value,
-      price: price.value,
-      categoryId: category.value,
+      price: parseFloat(price.value),
+      category_id: parseInt(category.value),
       location: location.value,
       quantity: quantity.value
     }


### PR DESCRIPTION
Description of PR that completes issue here...
Bug was blocking user from adding new product to their store. 

## Changes

- Updated pages/products/new.js to match back end language
-  added methods to change the strings provided to integers

## Requests / Responses


## Testing

Description of how to test code...

- [ ] make sure you are pulling the related back end
- [ ] log into an account that has a store
- [ ] go to the store page and add a product
- [ ] product prices can now have decimels as well


## Related Issues

- Fixes #[81](https://github.com/day-cohort-70/bangazon-api-i-like-planes-api/issues/81)